### PR TITLE
Add description for new nav-button-group element

### DIFF
--- a/unit-defs/manual_iqb-scripted.md
+++ b/unit-defs/manual_iqb-scripted.md
@@ -139,7 +139,7 @@ nav-button-group ermöglicht das Einfügen von Navigationselementen. Art und Rei
 
 | Schlüsselwort | Parameter |
 | :------------- | :------------- |
-| `if-nav-button-group` | 1. Liste der Optionen, jeweils getrennt durch ##
+| `nav-button-group` | 1. Liste der Optionen, jeweils getrennt durch ##
 
 #### Beispiele
 ```

--- a/unit-defs/manual_iqb-scripted.md
+++ b/unit-defs/manual_iqb-scripted.md
@@ -132,3 +132,17 @@ der Wert **nicht** mit dem Sollwert übereinstimmt.
 |  | 2. Wert|
 | `if-else` | *keine*|
 | `if-end` | *keine*|
+
+## Navigation
+nav-button-group ermöglicht das Einfügen von Navigationselementen. Art und Reihenfolge können gewählt werden. Mögliche Bedienelemente sind:
+`next`, `previous`, `first`, `last` und `end`.
+
+| Schlüsselwort | Parameter |
+| :------------- | :------------- |
+| `if-nav-button-group` | 1. Liste der Optionen, jeweils getrennt durch ##
+
+#### Beispiele
+```
+nav-button-group::previous##next##first##last##end
+nav-button-group::next
+```


### PR DESCRIPTION
Ich bin nicht mehr 100% sicher, wie wir uns geeinigt hatten, aber ich glaube das kommt hin. Man kann über die Parameter die anzuzeigenden Knöpfe in beliebiger Reihenfolge angeben.
Wenn kein Parameter gegeben ist oder einer auftaucht, der nicht in der Liste steht, gibt es einen Fehler im Abi-Player.